### PR TITLE
Add switch to turn off prefix extraction

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -55,6 +55,7 @@ public final class PartialFormatter {
     var prefixBeforeNationalNumber = String()
     var shouldAddSpaceAfterNationalPrefix = false
     var withPrefix = true
+    var extractsPrefixIfNeeded = true
 
     // MARK: Status
 
@@ -188,10 +189,14 @@ public final class PartialFormatter {
 
     // MARK: Formatting Extractions
 
+    private func shouldExtractPrefix(from number: String) -> Bool {
+        return extractsPrefixIfNeeded || withPrefix || number.starts(with: "+")
+    }
+
     func extractIDD(_ rawNumber: String) -> String {
         var processedNumber = rawNumber
         do {
-            if let internationalPrefix = currentMetadata?.internationalPrefix {
+            if shouldExtractPrefix(from: processedNumber), let internationalPrefix = currentMetadata?.internationalPrefix {
                 let prefixPattern = String(format: PhoneNumberPatterns.iddPattern, arguments: [internationalPrefix])
                 let matches = try regexManager?.matchedStringByRegex(prefixPattern, string: rawNumber)
                 if let m = matches?.first {
@@ -214,7 +219,7 @@ public final class PartialFormatter {
             self.prefixBeforeNationalNumber.append("1 ")
         } else {
             do {
-                if let nationalPrefix = currentMetadata?.nationalPrefixForParsing {
+                if shouldExtractPrefix(from: processedNumber), let nationalPrefix = currentMetadata?.nationalPrefixForParsing {
                     let nationalPrefixPattern = String(format: PhoneNumberPatterns.nationalPrefixParsingPattern, arguments: [nationalPrefix])
                     let matches = try regexManager?.matchedStringByRegex(nationalPrefixPattern, string: rawNumber)
                     if let m = matches?.first {

--- a/PhoneNumberKit/UI/PhoneNumberTextField.swift
+++ b/PhoneNumberKit/UI/PhoneNumberTextField.swift
@@ -90,6 +90,15 @@ open class PhoneNumberTextField: UITextField, UITextFieldDelegate {
         }
     }
 
+    public var extractsPrefixIfNeeded: Bool {
+        get {
+            partialFormatter.extractsPrefixIfNeeded
+        }
+        set {
+            partialFormatter.extractsPrefixIfNeeded = newValue
+        }
+    }
+
     #if compiler(>=5.1)
     /// Available on iOS 13 and above just.
     public var countryCodePlaceholderColor: UIColor = {

--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -455,6 +455,14 @@ class PartialFormatterTests: XCTestCase {
         XCTAssertEqual(formatted, "(120) 202-2022")
     }
 
+    func testWithPrefixDisabledAllowsNumberStratingFromSameDigitUA() {
+        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "UA")
+        partialFormatter.withPrefix = false
+        partialFormatter.extractsPrefixIfNeeded = false
+        let formatted = partialFormatter.formatPartial("0505050505")
+        XCTAssertEqual(formatted, "050 505 0505")
+    }
+
     func testWithPrefixDisabledAllowsNumberStratingFromSameDigitRU() {
         let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "RU")
         partialFormatter.withPrefix = false

--- a/PhoneNumberKitTests/PartialFormatterTests.swift
+++ b/PhoneNumberKitTests/PartialFormatterTests.swift
@@ -446,6 +446,22 @@ class PartialFormatterTests: XCTestCase {
         let formatted = partialFormatter.formatPartial("+420777123456")
         XCTAssertEqual(formatted, "777 123 456")
     }
+
+    func testWithPrefixDisabledAllowsNumberStratingFromSameDigitUS() {
+        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "US")
+        partialFormatter.withPrefix = false
+        partialFormatter.extractsPrefixIfNeeded = false
+        let formatted = partialFormatter.formatPartial("1202022022")
+        XCTAssertEqual(formatted, "(120) 202-2022")
+    }
+
+    func testWithPrefixDisabledAllowsNumberStratingFromSameDigitRU() {
+        let partialFormatter = PartialFormatter(phoneNumberKit: phoneNumberKit, defaultRegion: "RU")
+        partialFormatter.withPrefix = false
+        partialFormatter.extractsPrefixIfNeeded = false
+        let formatted = partialFormatter.formatPartial("8122345678")
+        XCTAssertEqual(formatted, "812 234-56-78")
+    }
     
     // MARK: region prediction
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can customize your TextField UI in the following ways
 
 - `withFlag` will display the country code for the `currentRegion`. The `flagButton` is displayed in the `leftView` of the text field with it's size set based off your text size.
 - `withExamplePlaceholder` uses `attributedPlaceholder` to show an example number for the `currentRegion`. In addition when `withPrefix` is set, the country code's prefix will automatically be inserted and removed when editing changes.
+- When `withPrefix` is set to `false`, by default user will not be able to type in the first digit if it matches the prefix. This behaviour can be turned off by turning off the `extractsPrefixIfNeeded` flag.
 
 PhoneNumberTextField automatically formats phone numbers and gives the user full editing capabilities. If you want to customize you can use the PartialFormatter directly. The default region code is automatically computed but can be overridden if needed (see the example given below).
 


### PR DESCRIPTION
In the current version of `PartialFormatter` when `withPrefix` is set to `false`, by default user will not be able to type in the first digit if it matches the last digit of the country code. So in the countries where same digit allowed as the immediate next digit after the country code, user will not be able to type in a valid number.
 
This may also prevent user from typing in a valid number in those countries where specific rules apply to phone numbers that require one or more last digits of international country code being always included in the number.

This MR adds `extractsPrefixIfNeeded` flag which allows to turn off the current extraction behaviour when set to `false`. 

This is partially related to what is described in the issue https://github.com/marmelroy/PhoneNumberKit/issues/453 with the difference in that it that issue describes user being unable to start their number with the digit matching national prefix.

Please, note: this property will not affect formatter behaviour when `withPrefix` is set to `true`.